### PR TITLE
Search io transaction when getting SC calls

### DIFF
--- a/lib/archethic/p2p/message/get_contract_calls.ex
+++ b/lib/archethic/p2p/message/get_contract_calls.ex
@@ -25,7 +25,7 @@ defmodule Archethic.P2P.Message.GetContractCalls do
 
     # will crash if a task did not succeed
     transactions =
-      Task.async_stream(transaction_addresses, &TransactionChain.get_transaction(&1))
+      Task.async_stream(transaction_addresses, &TransactionChain.get_transaction(&1, [], :io))
       |> Stream.map(fn {:ok, {:ok, tx}} -> tx end)
       |> Enum.to_list()
 


### PR DESCRIPTION
# Description

There is an issue when processing the message `GetContractCalls`. The storage nodes of the smart contract will receive the trigger transactions as io transaction. Hence the node need to search for the transaction in the io part of the DB also.
The current implementation is working with a low number of node as they are all storage node of any transaction

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
