### PR TITLE
Fix spent? flag regression on explorer

### DIFF
--- a/lib/archethic_web/explorer/live/transaction_details_live.ex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.ex
@@ -243,13 +243,11 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
         ledger_inputs = Enum.reject(inputs, &(&1.type == :call))
         contract_inputs = Enum.filter(inputs, &(&1.type == :call))
 
-        inputs = filter_inputs(ledger_inputs, unspent_outputs)
-
-        assigns = [inputs: inputs, calls: contract_inputs]
+        assigns = [inputs: ledger_inputs, calls: contract_inputs]
 
         send(me, {:async_assign, assigns})
 
-        get_token_addresses([], inputs)
+        get_token_addresses([], ledger_inputs)
         |> get_token_addresses(unspent_outputs)
         |> get_token_addresses(transaction_movements)
         |> get_token_addresses(token_transfers)
@@ -364,7 +362,7 @@ defmodule ArchethicWeb.Explorer.TransactionDetailsLive do
     end
   end
 
-  defp filter_inputs(inputs, utxos) do
+  def filter_inputs(inputs, utxos) do
     Enum.reject(inputs, fn input ->
       Enum.any?(utxos, &similar?(input, &1))
     end)

--- a/lib/archethic_web/explorer/live/transaction_details_live.html.heex
+++ b/lib/archethic_web/explorer/live/transaction_details_live.html.heex
@@ -571,7 +571,12 @@
 
             <%!----------------------------- INPUTS --------------------------------%>
             <div class="columns">
-              <% inputs_count = Enum.count(@inputs) %>
+              <% filtered_inputs =
+                filter_inputs(
+                  @inputs,
+                  @transaction.validation_stamp.ledger_operations.unspent_outputs
+                ) %>
+              <% inputs_count = Enum.count(filtered_inputs) %>
               <div class="column ae-left-heading is-2">
                 <p>Inputs (<%= inputs_count %>)</p>
               </div>
@@ -581,7 +586,7 @@
                   <div></div>
                 <% else %>
                   <InputsList.display_all
-                    inputs={@inputs}
+                    inputs={filtered_inputs}
                     socket={@socket}
                     uco_price_at_time={@uco_price_at_time}
                     uco_price_now={@uco_price_now}


### PR DESCRIPTION
# Description

Fixes a regression of the spent? flag in the explorer, unspent outputs where always flagged as unspent while they should be

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created multiple transaction in faucet chain, past transaction has an spent uco UTXO.
Also created a transaction that contains UTXO and inputs and both are well displayed

# Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing unit tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules
