### PR TITLE
Handle sync errors when downloading transactions

### DIFF
--- a/lib/archethic/self_repair/sync.ex
+++ b/lib/archethic/self_repair/sync.ex
@@ -489,17 +489,37 @@ defmodule Archethic.SelfRepair.Sync do
       max_concurrency: System.schedulers_online() * 2,
       timeout: Message.get_max_timeout() + 2000
     )
-    |> Stream.each(fn {:ok, {attestation, tx, inputs}} ->
-      :ok =
-        TransactionHandler.process_transaction_data(
-          attestation,
-          tx,
-          inputs,
-          download_nodes,
-          node_key
-        )
+    |> Stream.zip(attestations)
+    |> Stream.each(fn
+      {{:ok, {attestation, tx, inputs}}, _original_attestation} ->
+        :ok =
+          TransactionHandler.process_transaction_data(
+            attestation,
+            tx,
+            inputs,
+            download_nodes,
+            node_key
+          )
+
+      {{:exit, reason}, %ReplicationAttestation{
+         transaction_summary: %TransactionSummary{address: address}
+       }} ->
+        log_synchronization_failure(address, reason)
+        :ok
+
+      {{:error, reason}, %ReplicationAttestation{
+         transaction_summary: %TransactionSummary{address: address}
+       }} ->
+        log_synchronization_failure(address, reason)
+        :ok
     end)
     |> Stream.run()
+  end
+
+  defp log_synchronization_failure(address, reason) do
+    Logger.error(
+      "Failed to synchronize transaction #{Base.encode16(address)}: #{inspect(reason)}"
+    )
   end
 
   defp consolidate_recipients(


### PR DESCRIPTION
## Summary
- handle `Task.Supervisor.async_stream/3` responses explicitly during transaction synchronization
- continue processing when tasks exit or return errors by logging the failure and returning `:ok`
- add helper to log the transaction address and reason for synchronization failures

## Testing
- not run (mix executable unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e15ce3a29883299af163e05252029c